### PR TITLE
adds image and text helpers. Text can specify the number of sentences…

### DIFF
--- a/lib/template-builder.js
+++ b/lib/template-builder.js
@@ -16,6 +16,14 @@ const state = {
   registeredComponents: []
 };
 
+const shuffle = (array) => {
+  for (let i = array.length - 1; i > 0; i--) {
+     const j = Math.floor(Math.random() * (i + 1));
+     [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
 Handlebars.registerHelper('repeat', repeatHelper);
 
 Handlebars.registerHelper('equals', (arg1, arg2, options) => {

--- a/lib/template-builder.js
+++ b/lib/template-builder.js
@@ -22,7 +22,7 @@ const shuffle = (array) => {
      [array[i], array[j]] = [array[j], array[i]];
   }
   return array;
-}
+};
 
 Handlebars.registerHelper('repeat', repeatHelper);
 
@@ -33,7 +33,7 @@ Handlebars.registerHelper('equals', (arg1, arg2, options) => {
 Handlebars.registerHelper('contains', (needle, haystack, options) => {
   const escapedNeedle = Handlebars.escapeExpression(needle);
   const escapedHaystack = Handlebars.escapeExpression(haystack);
-  return (escapedHaystack.indexOf(escapedNeedle) > -1) 
+  return (escapedHaystack.indexOf(escapedNeedle) > -1)
     ? options.fn(this) : options.inverse(this);
 });
 
@@ -68,18 +68,17 @@ Handlebars.registerHelper('image', (options) => {
   } else {
     return `https://source.unsplash.com/${size}`
   }
-
 });
 
 const parseTemplate = (file) => {
   const fileData = fs.readFileSync(file, 'utf-8');
   if (!fileData) return { template: '', data: {} };
-  
+
   const {
     __content: template,
     ...data
   } = yamlFront.loadFront(fileData);
-  
+
   return {
     template,
     data

--- a/lib/template-builder.js
+++ b/lib/template-builder.js
@@ -17,14 +17,50 @@ const state = {
 };
 
 Handlebars.registerHelper('repeat', repeatHelper);
+
 Handlebars.registerHelper('equals', (arg1, arg2, options) => {
   return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
 });
+
 Handlebars.registerHelper('contains', (needle, haystack, options) => {
   const escapedNeedle = Handlebars.escapeExpression(needle);
   const escapedHaystack = Handlebars.escapeExpression(haystack);
   return (escapedHaystack.indexOf(escapedNeedle) > -1) 
     ? options.fn(this) : options.inverse(this);
+});
+
+Handlebars.registerHelper('text', (length) => {
+  const string = 'Fusce eget auctor elit, nec auctor nibh. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae. Cras auctor varius volutpat. Phasellus tempor felis ligula, ut euismod metus varius non. Suspendisse neque massa, porttitor non condimentum eget, pulvinar ac libero. Vivamus in congue mauris. Proin eget sapien id ipsum dictum rhoncus ut consequat libero. Aliquam lacus velit, viverra in ultrices vitae, euismod eget sem. Curabitur quis ultrices risus, sit amet interdum nulla. Vestibulum tincidunt mi nunc, aliquam tempus tortor convallis ac. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus suscipit tempor ligula, nec scelerisque lacus finibus ai. Duis a porta massa, vel semper mi. Aenean in pharetra turpis. Fusce id malesuada libero. Integer cursus arcu vel odio efficitur sagittis.'
+  const sentences = shuffle(string.split('. '));
+  const stop = typeof length === 'object' ? 1 : length;
+  const requested = sentences.splice(0, stop);
+  return requested.join('. ');
+});
+
+Handlebars.registerHelper('image', (options) => {
+  const args = options.hash;
+  const random = args.random;
+  const keywords = args.keywords;
+  const size = args.size;
+
+  if (!args.size) {
+    throw new Error(`Please add a size to this image. ex. "250x300"`);
+  }
+
+  if (args.length > 3) {
+    throw new Error(`Expected 1, 2 or 3 arguments, but got ${args.length}`);
+  }
+
+  if (keywords) {
+    return `https://source.unsplash.com/${size}?${keywords.replace(/\s/g, '')}`
+  } else if (random) {
+    const words = ['fun', 'nature', 'person', 'tech', 'fashion', 'office', 'food', 'film', 'health', 'architecture'];
+    const term = words[Math.floor(Math.random() * words.length)];
+    return `https://source.unsplash.com/${size}?${term}`;
+  } else {
+    return `https://source.unsplash.com/${size}`
+  }
+
 });
 
 const parseTemplate = (file) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kps3/hbs-template-builder",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Builds handlebars templates using components/layout",
   "main": "index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
adds image and text helpers. 
Text can specify the number of sentences. 
Image can specify a size, keywords, or a random sample from predefined keywords. The images come from unsplash
ex {{text}} one sentence without a period. Useful for headlines
ex. {{text 3}} for 3 random sentences
ex. {{image size="1920x1080}} for a random image at that size
ex. {{image size="300x300 keywords="plants, nature"}} gets a 300x300 image within those keywords
ex. {{image size="300x500 random="true"}} useful for lists with images to get different images within that list. If random is not specified all images in the list will be the same